### PR TITLE
Remove direct calls to gai_strerror (no longer supported on Windows)

### DIFF
--- a/ljsocket.lua
+++ b/ljsocket.lua
@@ -415,7 +415,7 @@ do
             return true
         end
 
-        return nil, ffi.string(C.gai_strerror(ret))
+        return nil, socket.lasterror(ret)
     end
 
     function socket.getnameinfo(address, length, host, hostlen, serv, servlen, flags)
@@ -424,7 +424,7 @@ do
             return true
         end
 
-        return nil, ffi.string(C.gai_strerror(ret))
+        return nil, socket.lasterror(ret)
     end
 
     do


### PR DESCRIPTION
The function `gai_strerror` is (no longer?) available on Windows. Calls result in an `cannot resolve symbol 'gai_strerror': The specified procedure could not be found.` error. This merge requests removes calls to this function and uses the generic function `lasterror()`.